### PR TITLE
values git_data_dirs has been removed to version 18.0, has been repla…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The domain and URL at which the GitLab instance will be accessible. This is set 
     gitlab_git_data_dir: "/var/opt/gitlab/git-data/repositories"
 
 The `gitlab_git_data_dir` is the location where all the Git repositories will be stored. You can use a shared drive or any path on the system.
+Note: This default value has changed for compatibility with Gitlab versions above 18.0.0 See https://docs.gitlab.com/omnibus/settings/configuration.html#migrating-from-git_data_dirs for migration instructions.
 
     gitlab_backup_path: "/var/opt/gitlab/backups"
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The domain and URL at which the GitLab instance will be accessible. This is set as the `external_url` configuration setting in `gitlab.rb`, and if you want to run GitLab on a different port (besides 80/443), you can specify the port here (e.g. `https://gitlab:8443/` for port 8443).
 
-    gitlab_git_data_dir: "/var/opt/gitlab/git-data"
+    gitlab_git_data_dir: "/var/opt/gitlab/git-data/repositories"
 
 The `gitlab_git_data_dir` is the location where all the Git repositories will be stored. You can use a shared drive or any path on the system.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # General config.
 gitlab_domain: gitlab
 gitlab_external_url: "https://{{ gitlab_domain }}/"
-gitlab_git_data_dir: "/var/opt/gitlab/git-data"
+gitlab_git_data_dir: "/var/opt/gitlab/git-data/repositories"
 gitlab_edition: "gitlab-ce"
 gitlab_version: ''
 gitlab_backup_path: "/var/opt/gitlab/backups"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,18 @@
   poll: 5
   when: not gitlab_file.stat.exists
 
+- name: Gather package facts
+  package_facts:
+    manager: auto
+
+- name: Fetch gitlab installed version
+  set_fact:
+    gitlab_installed_version: "{{ ansible_facts.packages[gitlab_edition][0].version }}"
+
+- name: Is gitlab version post 18.0.0 ?
+  set_fact:
+    is_gitlab_version_post_18: "{{ gitlab_installed_version is version_compare('18.0.0', '>=') }}"
+
 # Start and configure GitLab. Sometimes the first run fails, but after that,
 # restarts fix problems, so ignore failures on this run.
 - name: Reconfigure GitLab (first run).

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -29,7 +29,6 @@ letsencrypt['auto_renew'] = {{ gitlab_letsencrypt_auto_renew | lower }}
 {% endif %}
 
 # The directory where Git repositories will be stored.
-#git_data_dirs({"default" => {"path" => "{{ gitlab_git_data_dir }}"} })
 gitaly['configuration'] = {storage: [{name: 'default',path: '/var/opt/gitlab/git-data/repositories',},],}
 
 # The directory where Gitlab backups will be stored

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -29,7 +29,8 @@ letsencrypt['auto_renew'] = {{ gitlab_letsencrypt_auto_renew | lower }}
 {% endif %}
 
 # The directory where Git repositories will be stored.
-git_data_dirs({"default" => {"path" => "{{ gitlab_git_data_dir }}"} })
+#git_data_dirs({"default" => {"path" => "{{ gitlab_git_data_dir }}"} })
+gitaly['configuration'] = {storage: [{name: 'default',path: '/var/opt/gitlab/git-data/repositories',},],}
 
 # The directory where Gitlab backups will be stored
 gitlab_rails['backup_path'] = "{{ gitlab_backup_path }}"

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -29,7 +29,11 @@ letsencrypt['auto_renew'] = {{ gitlab_letsencrypt_auto_renew | lower }}
 {% endif %}
 
 # The directory where Git repositories will be stored.
+{% if is_gitlab_version_post_18 %}
 gitaly['configuration'] = {storage: [{name: 'default',path: '{{ gitlab_git_data_dir }}',},],}
+{% else %}
+git_data_dirs({"default" => {"path" => "{{ gitlab_git_data_dir }}"} })
+{% endif %}
 
 # The directory where Gitlab backups will be stored
 gitlab_rails['backup_path'] = "{{ gitlab_backup_path }}"

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -29,7 +29,7 @@ letsencrypt['auto_renew'] = {{ gitlab_letsencrypt_auto_renew | lower }}
 {% endif %}
 
 # The directory where Git repositories will be stored.
-gitaly['configuration'] = {storage: [{name: 'default',path: '/var/opt/gitlab/git-data/repositories',},],}
+gitaly['configuration'] = {storage: [{name: 'default',path: '{{ gitlab_git_data_dir }}',},],}
 
 # The directory where Gitlab backups will be stored
 gitlab_rails['backup_path'] = "{{ gitlab_backup_path }}"


### PR DESCRIPTION
Upgrade to 18.0 failed due a config change
git_data_dirs has been deprecated since 17.8 and was removed in 18.0. See https://docs.gitlab.com/omnibus/settings/configuration.html#migrating-from-git_data_dirs`` for migration instructions